### PR TITLE
revert to official docker:dind after upgrade to Alpine 3.13

### DIFF
--- a/transformer-runner/Dockerfile
+++ b/transformer-runner/Dockerfile
@@ -5,8 +5,7 @@ RUN git clone https://github.com/deislabs/oras.git \
   && cd ./oras/cmd/oras && git checkout 96cd90423303f1bb42bd043cb4c36085e6e91e8e  \
   && go build -v -o /usr/bin/oras
 
-# this can be replaced with the oficial image after https://github.com/docker-library/docker/pull/290 lands
-FROM hades32/docker:dind-alpine-3.13
+FROM docker:dind
 ARG NPM_TOKEN
 WORKDIR /usr/src/app
 COPY --from=oras-base /usr/bin/oras /usr/bin/oras


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>