### PR TITLE
add CPU arch emulation for cross-compilation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,14 @@ services:
       - garbage-collector:/root
       - shared-docker-socket:/var/run
 
+  # this auto-registers QEMU to run non-native binaries
+  # can be leveraged for `docker build --platform=linux/arm64` etc
+  binfmt-hook:
+    image: multiarch/qemu-user-static
+    command: [ '--reset', '-p', 'yes' ]
+    privileged: true
+    restart: 'no'
+
 volumes:
   registry-data: {}
   garbage-collector: {}


### PR DESCRIPTION
as hinted by Robert in https://www.flowdock.com/app/rulemotion/resin-tech/threads/2a8SOEXeDDL8FU8d10dvA0nNtCX we're easily able to add multi-arch support with this.

The missing parts to make this work are:
* architecture definition in the transformer type
* using that info in the runner when doing the docker run