### PR TITLE
don't fail if status data didn't exist before the task run

### DIFF
--- a/transformer-runner/src/jellyfish.ts
+++ b/transformer-runner/src/jellyfish.ts
@@ -151,12 +151,12 @@ export default class Jellyfish {
 		
 		await this.sdk.card.update(task.id, task.type, [
 			{
-				op: 'replace',
+				op: 'add',
 				path: '/data/status',
 				value: status,
 			},
 			{
-				op: 'replace',
+				op: 'add',
 				path: '/data/statusMetadata',
 				value: metaData
 			},


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>