### PR TITLE
use docker-volume for temporary docker storage (too big for RAM)

### DIFF
--- a/testdata/generic-source.yml
+++ b/testdata/generic-source.yml
@@ -1,7 +1,7 @@
 type: generic-source@1.0.0
 name: source of transformer-worker
 slug: generic-source-transformer-worker
-version: 0.0.2
+version: 0.0.5
 data:
   $transformer:
     baseSlug: transformer-worker

--- a/transformer-runner/entrypoint.sh
+++ b/transformer-runner/entrypoint.sh
@@ -25,5 +25,6 @@ export WORKER_JF_TOKEN="${WORKER_JF_TOKEN:-$TOKEN}"
     done
 )& 
 
-sleep 2
-npm start
+while ! docker info >/dev/null 2>&1; do sleep 1s; done
+
+exec node build/index.js

--- a/transformer-runner/src/runner.ts
+++ b/transformer-runner/src/runner.ts
@@ -162,18 +162,19 @@ async function runTransformer(task: TaskContract, transformerImageRef: string) {
 				Binds: [
 					`${path.resolve(directory.input(task))}:/input/:ro`,
 					`${path.resolve(directory.output(task))}:/output/`,
+					'tmp-docker:/var/lib/docker',
 				],
-				Tmpfs: {
-					'/var/lib/docker': 'rw'
-				}
 			},
 		} as ContainerCreateOptions,
 	);
 
-	console.log("[WORKER] run result", JSON.stringify(runResult));
-
 	const output = runResult[0];
-	// const container = runResult[1];
+	const container = runResult[1];
+
+	await docker.getContainer(container.id).remove({force: true})
+	await docker.getVolume('tmp-docker').remove({force: true})
+
+	console.log("[WORKER] run result", JSON.stringify(runResult));
 
 	return output.StatusCode;
 }


### PR DESCRIPTION
also, we forgot to remove our created containers

Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>