### PR TITLE
update runtime to 0.0.6

### DIFF
--- a/transformer-runner/package-lock.json
+++ b/transformer-runner/package-lock.json
@@ -645,9 +645,9 @@
       }
     },
     "@balena/transformer-runtime": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@balena/transformer-runtime/-/transformer-runtime-0.0.5.tgz",
-      "integrity": "sha512-WX8nlsVaxRWsJ6Fr6mJ6C3I5Zo1DvrXhdLeu398tzQWh5V4wlNDu3dBwEUUWy8tgPQDQ/q39EFlYsDHVe3uGHg==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@balena/transformer-runtime/-/transformer-runtime-0.0.6.tgz",
+      "integrity": "sha512-VWY6RY55dNz1H7UIloX8lLeZkCJWMmQPRJx9g7IlIUgWFKqzh8KFtZD2Lv8UG126IbGV8h5oy+Z6BdxChtRENg==",
       "requires": {
         "dockerode": "^3.3.0",
         "node-rsa": "^1.1.1"

--- a/transformer-runner/package.json
+++ b/transformer-runner/package.json
@@ -17,7 +17,7 @@
     "@ahmadnassri/spawn-promise": "^1.2.0",
     "@balena/jellyfish-client-sdk": "^5.5.0",
     "@balena/jellyfish-jellyscript": "^4.9.11",
-    "@balena/transformer-runtime": "0.0.5",
+    "@balena/transformer-runtime": "^0.0.6",
     "@types/rewire": "^2.5.28",
     "dockerode": "^3.3.0",
     "fast-json-patch": "^3.0.0-1",


### PR DESCRIPTION
should fix secret decoding

Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>