### PR TITLE
backflow v2

### DIFF
--- a/transformer-runner/src/jellyfish.ts
+++ b/transformer-runner/src/jellyfish.ts
@@ -400,7 +400,7 @@ export default class Jellyfish {
 			(c) =>
 				({
 					op: 'add',
-					path: `/data/$transformer/backflow/${c.id}`,
+					path: '/data/$transformer/backflow/-',
 					value: c,
 				} as AddOperation<Contract>),
 		);
@@ -409,7 +409,7 @@ export default class Jellyfish {
 			patch.unshift({
 				op: 'add',
 				path: '/data/$transformer/backflow',
-				value: {},
+				value: [],
 			} as AddOperation<any>);
 		}
 

--- a/transformer-runner/src/types.ts
+++ b/transformer-runner/src/types.ts
@@ -20,7 +20,7 @@ interface ArtifactData extends ContractData {
 		baseSlug?: string;
 		slugSuffix?: string; // used to allow transformers customization of generated slugs. needed when creating multiple instances of same type
 		encryptedSecrets?: any;
-		backflow?: Record<string, Contract<any>>;
+		backflow?: ArtifactContract[];
 	};
 }
 export interface ArtifactContract extends Contract<ArtifactData> {}


### PR DESCRIPTION
simplify backflow to always backflow all output contracts, but only one level up. Also have the worker pass in these contracts with their artifacts to transformer runs

Resolves https://github.com/product-os/product-os/issues/1185