### PR TITLE
Do not pull artifact if artifactReady is false

### DIFF
--- a/transformer-runner/src/runner.ts
+++ b/transformer-runner/src/runner.ts
@@ -144,7 +144,8 @@ async function prepareWorkspace(
 		),
 	);
 
-	if (task.data.transformer.data.inputType != 'contract-only') {
+	if (inputContract.data.$transformer?.artifactReady !== false &&
+		task.data.transformer.data.inputType != 'contract-only') {
 		await registry.pullArtifact(
 			createArtifactReference(inputContract),
 			inputArtifactDir,


### PR DESCRIPTION
Skip artifact pull if and only if input contract has artifactReady set to false

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>