### PR TITLE
ensure backflowed data considers latest formula updates

### DIFF
--- a/transformer-runner/src/runner.ts
+++ b/transformer-runner/src/runner.ts
@@ -322,7 +322,7 @@ async function processBackflow(
 	}
 
 	// Propagate backflow recursively from input contract upstream
-	const backflowLimit = 20;
+	const backflowLimit = 100;
 
 	const propagate = async (contract: ArtifactContract, step: number = 1) => {
 		if (step > backflowLimit) {
@@ -334,7 +334,9 @@ async function processBackflow(
 
 		const parent = await jf.getUpstreamContract(contract);
 		if (parent) {
-			await jf.updateBackflow(contract, parent);
+			// the previous step might have resulted in changes to formulas
+			const freshContract = (await jf.getContract<ArtifactContract>(contract.id))!;
+			await jf.updateBackflow(freshContract, parent);
 			await propagate(parent, step + 1);
 		}
 	};


### PR DESCRIPTION
before it would have been possible that the backflow recursion would contain old data, not taking formulas into account.

Also upping the recursion limit to 100 as 20 seemed rather low.